### PR TITLE
feat: Select Type Bottom Sheet 컴포넌트 호출

### DIFF
--- a/src/app/(bottom-sheet)/Select/index.tsx
+++ b/src/app/(bottom-sheet)/Select/index.tsx
@@ -1,0 +1,34 @@
+import Label from "@/src/components/Label";
+import React from "react";
+import { Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { SelectBottomSheetProps } from "./props.type";
+
+const SelectBottomSheet = ({
+  title,
+  selectOptions,
+}: SelectBottomSheetProps) => {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <View style={{ paddingBottom: bottom }} className={"pt-2"}>
+      <View className="pt-2 px-5">
+        <Text className="text-title5-bold">{title}</Text>
+
+        <View className="pt-2 pb-4">
+          {selectOptions.map((select) => (
+            <Label
+              key={select.label}
+              icon={select.icon}
+              variant={select.variant}
+            >
+              {select.label}
+            </Label>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default SelectBottomSheet;

--- a/src/app/(bottom-sheet)/Select/props.type.ts
+++ b/src/app/(bottom-sheet)/Select/props.type.ts
@@ -1,0 +1,9 @@
+import { SelectOption } from "@/src/types/bottomSheet";
+
+interface SelectBottomSheetProps {
+  title: string;
+
+  selectOptions: SelectOption[];
+}
+
+export type { SelectBottomSheetProps };

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,3 +1,4 @@
+import "@/src/libs/remapProps";
 import "@/src/styles/global.css";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
@@ -10,6 +11,8 @@ import {
   DefaultTheme,
   ThemeProvider,
 } from "@react-navigation/native";
+import BottomSheet from "../components/BottomSheet";
+import useBottomSheet from "../hooks/useBottomSheet";
 import useModal from "../hooks/useModal";
 
 export const unstable_settings = {
@@ -19,6 +22,7 @@ export const unstable_settings = {
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const { isOpen: isModalOpen } = useModal();
+  const { isOpen: isBottomSheetOpen } = useBottomSheet();
 
   return (
     <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
@@ -29,6 +33,7 @@ export default function RootLayout() {
       <StatusBar style="auto" />
 
       {isModalOpen && <Modal />}
+      {isBottomSheetOpen && <BottomSheet />}
     </ThemeProvider>
   );
 }

--- a/src/components/BottomSheet/animate.ts
+++ b/src/components/BottomSheet/animate.ts
@@ -1,0 +1,9 @@
+import { SlideOutDown, SlideOutUp } from "react-native-reanimated";
+
+const bottomSheetAnimation = {
+  entering: SlideOutUp.duration(200),
+
+  exiting: SlideOutDown.duration(200),
+};
+
+export default bottomSheetAnimation;

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,0 +1,57 @@
+import SelectBottomSheet from "@/src/app/(bottom-sheet)/Select";
+import bottomSheetAtom from "@/src/store/bottomSheet";
+import clsx from "clsx";
+import { useAtom } from "jotai";
+import React from "react";
+import { Pressable } from "react-native";
+import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import bottomSheetAnimation from "./animate";
+
+const BottomSheet = () => {
+  const [bottomSheetState, setBottomSheetState] = useAtom(bottomSheetAtom);
+  const { bottom } = useSafeAreaInsets();
+
+  const renderBottomSheet = () => {
+    if (!bottomSheetState.visible || !bottomSheetState.payload) return null;
+
+    switch (bottomSheetState.variant) {
+      case "SELECT":
+        return (
+          <SelectBottomSheet
+            title={bottomSheetState.payload.title}
+            selectOptions={bottomSheetState.payload.selectOptions}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Animated.View
+      className="absolute w-full h-full z-50 items-center justify-end"
+      entering={FadeIn.duration(200)}
+      exiting={FadeOut.duration(200)}
+    >
+      <Pressable
+        className="absolute opacity-50 bg-black w-full h-full"
+        onPress={() =>
+          setBottomSheetState({
+            ...bottomSheetState,
+            visible: false,
+          })
+        }
+      />
+
+      <Animated.View
+        className={clsx("bg-surfaceContainer w-full pt-2 rounded-t-3xl")}
+        {...bottomSheetAnimation}
+      >
+        {renderBottomSheet()}
+      </Animated.View>
+    </Animated.View>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,16 +1,14 @@
 import SelectBottomSheet from "@/src/app/(bottom-sheet)/Select";
 import bottomSheetAtom from "@/src/store/bottomSheet";
-import clsx from "clsx";
 import { useAtom } from "jotai";
 import React from "react";
 import { Pressable } from "react-native";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import bottomSheetAnimation from "./animate";
+import bottomSheetStyle from "./style";
 
 const BottomSheet = () => {
   const [bottomSheetState, setBottomSheetState] = useAtom(bottomSheetAtom);
-  const { bottom } = useSafeAreaInsets();
 
   const renderBottomSheet = () => {
     if (!bottomSheetState.visible || !bottomSheetState.payload) return null;
@@ -30,12 +28,13 @@ const BottomSheet = () => {
 
   return (
     <Animated.View
-      className="absolute w-full h-full z-50 items-center justify-end"
+      className={bottomSheetStyle.variants.container}
       entering={FadeIn.duration(200)}
       exiting={FadeOut.duration(200)}
     >
+      {/* overlay */}
       <Pressable
-        className="absolute opacity-50 bg-black w-full h-full"
+        className={bottomSheetStyle.variants.overlay}
         onPress={() =>
           setBottomSheetState({
             ...bottomSheetState,
@@ -44,8 +43,9 @@ const BottomSheet = () => {
         }
       />
 
+      {/* sheet */}
       <Animated.View
-        className={clsx("bg-surfaceContainer w-full pt-2 rounded-t-3xl")}
+        className={bottomSheetStyle.variants.sheet}
         {...bottomSheetAnimation}
       >
         {renderBottomSheet()}

--- a/src/components/BottomSheet/style.ts
+++ b/src/components/BottomSheet/style.ts
@@ -1,0 +1,13 @@
+import { tv } from "tailwind-variants";
+
+const bottomSheetStyle = tv({
+  variants: {
+    container: "absolute w-full h-full z-50 items-center justify-end",
+
+    overlay: "absolute opacity-50 bg-black w-full h-full",
+
+    sheet: "bg-surfaceContainer w-full pt-2 rounded-t-3xl",
+  },
+});
+
+export default bottomSheetStyle;

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,0 +1,43 @@
+import clsx from "clsx";
+import * as LucideIcons from "lucide-react-native";
+import React from "react";
+import { Pressable, Text } from "react-native";
+import { LabelProps } from "./props.type";
+import labelStyle from "./style";
+
+type IconComponent = React.ComponentType<{ className?: string; size?: number }>;
+
+const Label = ({
+  icon,
+  onTap,
+  variant = "default",
+  children,
+  block = false,
+}: LabelProps) => {
+  const Icon =
+    typeof icon === "string"
+      ? (LucideIcons as unknown as Record<string, IconComponent>)[icon]
+      : (icon as IconComponent);
+
+  return (
+    <Pressable className={labelStyle.variants.container} onPress={onTap}>
+      {/* Icon 색상 바꾸기 */}
+      {Icon && (
+        <Icon
+          className={clsx("w-5 h-5", labelStyle.variants.variant[variant])}
+        />
+      )}
+
+      <Text
+        className={clsx(
+          labelStyle.variants.variant[variant],
+          block && labelStyle.variants.block,
+        )}
+      >
+        {children}
+      </Text>
+    </Pressable>
+  );
+};
+
+export default Label;

--- a/src/components/Label/props.type.ts
+++ b/src/components/Label/props.type.ts
@@ -1,0 +1,35 @@
+import { LucideIcon } from "lucide-react-native";
+import { GestureResponderEvent } from "react-native";
+
+type LabelVariant = "default" | "destructive";
+
+interface LabelProps {
+  /**
+   * 라벨 왼쪽에 표시될 아이콘 (Lucide 아이콘 컴포넌트)
+   */
+  icon?: string | LucideIcon;
+
+  /**
+   * 라벨의 색상 타입(default | destructive)
+   */
+  variant?: LabelVariant;
+
+  /**
+   * 라벨 클릭 시 실행될 이벤트 핸들러
+   */
+  onTap?: (e: GestureResponderEvent) => void;
+
+  /**
+   * 라벨 내부에 표시될 텍스트 내용 (필수)
+   */
+  children: string;
+
+  /**
+   * 라벨의 너비를 지정합니다.
+   * - true: 텍스트의 너비만큼만 차지합니다.
+   * - false: 전체 너비를 차지합니다.
+   */
+  block?: boolean;
+}
+
+export type { LabelProps };

--- a/src/components/Label/style.ts
+++ b/src/components/Label/style.ts
@@ -1,0 +1,17 @@
+import clsx from "clsx";
+import { tv } from "tailwind-variants";
+
+const labelStyle = tv({
+  variants: {
+    container: clsx("flex flex-row", "items-center", "gap-3 py-2.5"),
+
+    variant: {
+      default: clsx("text-onSurfaceVariant", "text-body2-medium"),
+      destructive: clsx("text-error", "text-body2-medium"),
+    },
+
+    block: "w-fit",
+  },
+});
+
+export default labelStyle;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -2,7 +2,7 @@ import AlertModal from "@/src/app/(modal)/Alert";
 import ConfirmModal from "@/src/app/(modal)/Confirm";
 import modalAtom from "@/src/store/modal";
 import { useAtomValue } from "jotai";
-import React, { useEffect } from "react";
+import React from "react";
 import { View } from "react-native";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import "../../libs/remapProps";
@@ -11,10 +11,6 @@ import modalStyle from "./style";
 
 const Modal = () => {
   const modalState = useAtomValue(modalAtom);
-
-  useEffect(() => {
-    console.log(modalState.variant);
-  }, [modalState]);
 
   const renderModal = () => {
     if (!modalState.visible || !modalState.payload) return null;

--- a/src/components/WebView/index.tsx
+++ b/src/components/WebView/index.tsx
@@ -17,7 +17,7 @@ const WebView = () => {
       <WebViewClient
         ref={webViewRef}
         source={{
-          uri: `${"http://172.16.20.182:3000"}`,
+          uri: `${"http://localhost:3000"}`,
         }}
         style={{
           backgroundColor: backgroundColor,

--- a/src/constants/event.ts
+++ b/src/constants/event.ts
@@ -3,7 +3,11 @@
  * 형식: [행동_대상_형태]
  * 예: OPEN_MODAL_CONFIRM, OPEN_BOTTOMSHEET_SELECT, OPEN_TOPSHEET_INFO
  */
-type BridgeGetEventToken = "NONE" | "OPEN_MODAL_CONFIRM" | "OPEN_MODAL_ALERT";
+type BridgeGetEventToken =
+  | "NONE"
+  | "OPEN_MODAL_CONFIRM"
+  | "OPEN_MODAL_ALERT"
+  | "OPEN_BOTTOMSHEET_SELECT";
 
 type BridgePostEventToken = "ACTION_CONFIRMED" | "ACTION_CANCELED";
 

--- a/src/hooks/useBottomSheet.tsx
+++ b/src/hooks/useBottomSheet.tsx
@@ -1,0 +1,28 @@
+import { useAtom } from "jotai";
+import bottomSheetAtom from "../store/bottomSheet";
+
+const useBottomSheet = () => {
+  const [bottomSheet, setBottomSheet] = useAtom(bottomSheetAtom);
+
+  const openBottomSheet = () => {
+    setBottomSheet({
+      ...bottomSheet,
+      visible: true,
+    });
+  };
+
+  const closeBottomSheet = () => {
+    setBottomSheet({
+      ...bottomSheet,
+      visible: false,
+      variant: null,
+      payload: null,
+    });
+  };
+
+  const isOpen = bottomSheet.visible;
+
+  return { openBottomSheet, closeBottomSheet, isOpen };
+};
+
+export default useBottomSheet;

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -2,11 +2,13 @@ import { useSetAtom } from "jotai";
 import { RefObject } from "react";
 import WebView, { WebViewMessageEvent } from "react-native-webview";
 import { getBridgeEventSegment } from "../libs/bridgeEvent";
+import bottomSheetAtom from "../store/bottomSheet";
 import modalAtom from "../store/modal";
 import { BridgeEvent } from "../types/bridgeEvnet";
 
 const useBridge = (webViewRef: RefObject<WebView | null>) => {
   const modalState = useSetAtom(modalAtom);
+  const bottomSheetState = useSetAtom(bottomSheetAtom);
 
   const getMessage = (event: WebViewMessageEvent) => {
     const response: BridgeEvent = JSON.parse(event.nativeEvent.data);
@@ -16,6 +18,14 @@ const useBridge = (webViewRef: RefObject<WebView | null>) => {
     switch (segments.target) {
       case "MODAL":
         modalState({
+          visible: segments.action === "OPEN" ? true : false,
+          variant: segments.variant,
+          payload: response.payload,
+        });
+        break;
+
+      case "BOTTOMSHEET":
+        bottomSheetState({
           visible: segments.action === "OPEN" ? true : false,
           variant: segments.variant,
           payload: response.payload,

--- a/src/libs/remapProps.ts
+++ b/src/libs/remapProps.ts
@@ -1,7 +1,7 @@
-import { Check } from "lucide-react-native";
+import * as LucideIcons from "lucide-react-native";
 import { cssInterop } from "nativewind";
 
-cssInterop(Check, {
+const interopConfig = {
   className: {
     target: "style",
     nativeStyleToProp: {
@@ -11,4 +11,9 @@ cssInterop(Check, {
       height: "size",
     },
   },
+} as const;
+
+// 모든 Lucide 아이콘에 대해 cssInterop 적용
+Object.values(LucideIcons).forEach((Icon) => {
+  cssInterop(Icon as LucideIcons.LucideIcon, interopConfig);
 });

--- a/src/store/bottomSheet.ts
+++ b/src/store/bottomSheet.ts
@@ -1,0 +1,10 @@
+import { atom } from "jotai";
+import { BottomSheetState } from "../types/bottomSheet";
+
+const bottomSheetAtom = atom<BottomSheetState>({
+  visible: false,
+  variant: null,
+  payload: null,
+});
+
+export default bottomSheetAtom;

--- a/src/types/bottomSheet.ts
+++ b/src/types/bottomSheet.ts
@@ -1,0 +1,25 @@
+import { Variant } from "./bridgeEvnet";
+
+type SelectOptionVariant = "default" | "destructive";
+
+interface SelectOption {
+  icon: string;
+  label: string;
+  variant: SelectOptionVariant;
+}
+
+interface BottomSheetData {
+  title: string;
+}
+
+interface SelectBottomSheetData extends BottomSheetData {
+  selectOptions: SelectOption[];
+}
+
+interface BottomSheetState {
+  visible: boolean;
+  variant: Variant | null;
+  payload: SelectBottomSheetData | null;
+}
+
+export type { BottomSheetState, SelectOption };

--- a/src/types/bridgeEvnet.ts
+++ b/src/types/bridgeEvnet.ts
@@ -1,8 +1,8 @@
 import { BridgeGetEventToken, BridgePostEventToken } from "../constants/event";
 
 type Action = "OPEN" | "CLOSE";
-type Target = "MODAL";
-type Variant = "CONFIRM" | "ALERT" | null;
+type Target = "MODAL" | "BOTTOMSHEET";
+type Variant = "CONFIRM" | "ALERT" | "SELECT" | null;
 
 interface BridgeEvent {
   type: BridgeGetEventToken | BridgePostEventToken;


### PR DESCRIPTION
## 변경 사항

- RN<->NextJS 브릿지 통신 Bottom Sheet 호출 구현
- 아이콘 `cssInterop` 추가 방식 변경
  - 기존 : 아이콘을 각각 타게팅 하여 cssInterop
  - 개선 : 모든 Lucide Icon에 cssInterop을 설정하여 모든 아이콘에 대한 `className` 설정 가능
     - className 세팅 가능 값
       - color
       - opacity
       - width
       - height

## 리뷰 필요

- 아이콘 / 텍스트 색상이 잘 전달되는지 확인 (variant : "destructive" | "default (optional)")
- 피그마와 디자인이 동일 혹은 유사한지 확인

close #6 
